### PR TITLE
Update to Bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_app_compute"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["Kjolnyr <kjolnyr@protonmail.com>"]
 edition = "2021"
 description = "App compute plugin for Bevy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,15 +13,18 @@ categories = ["game-development"]
 
 
 [dependencies]
-bevy = "0.10.1"
+bevy = "0.11"
 parking_lot = "0.12.1"
-wgpu = "0.15.1"
+wgpu = { version = "0.16.0", features = ["naga"] }
 codespan-reporting = "0.11.1"
 futures-lite = "1.13.0"
-bytemuck = "1.13.1"
+bytemuck = "1.4.0"
+naga = { version = "0.12.0", features = ["wgsl-in"] }
+naga_oil = "0.8.0"
 
 [dev-dependencies]
 rand = "0.8.5"
+bevy = { version = "0.11", features = ["wayland"] }
 
 [[example]]
 name = "simple"

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -31,9 +31,8 @@ impl ComputeWorker for SimpleComputeWorker {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(AppComputePlugin)
-        .add_plugin(AppComputeWorkerPlugin::<SimpleComputeWorker>::default())
-        .add_system(test)
+        .add_plugins((AppComputePlugin, AppComputeWorkerPlugin::<SimpleComputeWorker>::default()))
+        .add_systems(Update, test)
         .run();
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -31,7 +31,8 @@ impl ComputeWorker for SimpleComputeWorker {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugins((AppComputePlugin, AppComputeWorkerPlugin::<SimpleComputeWorker>::default()))
+        .add_plugin(AppComputePlugin)
+        .add_plugin(AppComputeWorkerPlugin::<SimpleComputeWorker>::default())
         .add_systems(Update, test)
         .run();
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -15,8 +15,8 @@ impl Plugin for AppComputePlugin {
         let render_device = app.world.resource::<RenderDevice>().clone();
 
         app.insert_resource(AppPipelineCache::new(render_device))
-            .add_system(extract_shaders.in_base_set(CoreSet::PreUpdate))
-            .add_system(process_pipeline_queue_system);
+            .add_systems(PreUpdate, extract_shaders)
+            .add_systems(Update, process_pipeline_queue_system);
     }
 }
 
@@ -38,11 +38,10 @@ impl<W: ComputeWorker> Plugin for AppComputeWorkerPlugin<W> {
         let worker = W::build(&mut app.world);
 
         app.insert_resource(worker)
-            .add_system(AppComputeWorker::<W>::extract_pipelines)
+            .add_systems(Update, AppComputeWorker::<W>::extract_pipelines)
             .add_systems(
-                (AppComputeWorker::<W>::unmap_all, AppComputeWorker::<W>::run)
-                    .chain()
-                    .in_base_set(CoreSet::PostUpdate),
+                PostUpdate,
+                (AppComputeWorker::<W>::unmap_all, AppComputeWorker::<W>::run).chain(),
             );
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -402,13 +402,13 @@ impl<W: ComputeWorker> AppComputeWorker<W> {
         pipeline_cache: Res<AppPipelineCache>,
     ) {
         for (uuid, cached_id) in &worker.cached_pipeline_ids.clone() {
-            let Some(pipeline) = worker.pipelines.get(&uuid) else { continue; };
+            let Some(pipeline) = worker.pipelines.get(uuid) else { continue; };
 
             if pipeline.is_some() {
                 continue;
             };
 
-            let cached_id = cached_id.clone();
+            let cached_id = *cached_id;
 
             worker.pipelines.insert(
                 *uuid,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -101,7 +101,7 @@ impl<W: ComputeWorker> From<&AppComputeWorkerBuilder<'_, W>> for AppComputeWorke
             steps: builder.steps.clone(),
             command_encoder,
             run_mode: builder.run_mode,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }
@@ -148,7 +148,7 @@ impl<W: ComputeWorker> AppComputeWorker<W> {
         let Some(encoder) = &mut self.command_encoder else { return Err(Error::EncoderIsNone) };
         {
             let mut cpass = encoder.begin_compute_pass(&ComputePassDescriptor { label: None });
-            cpass.set_pipeline(&pipeline);
+            cpass.set_pipeline(pipeline);
             cpass.set_bind_group(0, &bind_group, &[]);
             cpass.dispatch_workgroups(
                 compute_pass.workgroups[0],
@@ -193,7 +193,7 @@ impl<W: ComputeWorker> AppComputeWorker<W> {
                 else { return Err(Error::BufferNotFound(name.to_owned()))};
 
             encoder.copy_buffer_to_buffer(
-                &buffer,
+                buffer,
                 0,
                 &staging_buffer.buffer,
                 0,
@@ -243,8 +243,8 @@ impl<W: ComputeWorker> AppComputeWorker<W> {
 
     /// Try Read data from `target` staging buffer, return a single `B: Pod`
     #[inline]
-    pub fn try_read<'a, B: AnyBitPattern>(&'a self, target: &str) -> Result<B> {
-        let result = from_bytes::<B>(&self.try_read_raw(target)?).clone();
+    pub fn try_read<B: AnyBitPattern>(&self, target: &str) -> Result<B> {
+        let result = *from_bytes::<B>(&self.try_read_raw(target)?);
         Ok(result)
     }
 

--- a/src/worker_builder.rs
+++ b/src/worker_builder.rs
@@ -43,7 +43,7 @@ impl<'a, W: ComputeWorker> AppComputeWorkerBuilder<'a, W> {
             staging_buffers: HashMap::default(),
             steps: vec![],
             run_mode: RunMode::Continuous,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 
@@ -234,7 +234,7 @@ impl<'a, W: ComputeWorker> AppComputeWorkerBuilder<'a, W> {
 
         self.steps.push(Step::ComputePass(ComputePass {
             workgroups,
-            vars: vars.into_iter().map(|a| String::from(*a)).collect(),
+            vars: vars.iter().map(|a| String::from(*a)).collect(),
             shader_uuid: S::TYPE_UUID,
         }));
         self


### PR DESCRIPTION
Hey there,
since I've wanted to use this plugin in one of my projects (which uses Bevy 0.11), I decided to give it a try and upgrade it. The only major changes I had to make were to the PipelineCache, which was upgraded in Bevy 0.11 [(here)](https://github.com/bevyengine/bevy/blob/release-0.11.3/crates/bevy_render/src/render_resource/pipeline_cache.rs). 

Currently it does compile, but the examples do not work, because (for some reason) we cannot access the RenderDevice resource during plugin build [(this line)](https://github.com/ecrax/bevy_app_compute/blob/b4725dce07a8aebbd73169054e609f7e87f429f8/src/plugin.rs#L15). I can't manage to fix this, maybe you have an idea why this is or how to fix it?

Thanks for your work on this! :)