### PR TITLE
Update README - bad code in my_system example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ fn my_system(
 
     let result: Vec<f32> = compute_worker.read_vec("values");
 
-    compute_worker.write_slice("values", [2., 3., 4., 5.]);
+    compute_worker.write_slice::<f32>("values", &[2., 3., 4., 5.]);
 
     println!("got {:?}", result)
 }
@@ -176,3 +176,4 @@ See [examples](https://github.com/Kjolnyr/bevy_app_compute/tree/main/examples)
 | Bevy | bevy_app_compute |
 | ---- | ---------------- |
 | 0.16 | 0.16             |
+


### PR DESCRIPTION
Fixed the example code in my_system that leads to:
1. Not compiling, bcs. write_slice requires a slice, not a static table per se
2. After code is compiled, it crashes, bcs. rust assumed the slice wad f64, instead of f32